### PR TITLE
attempt to fix auto report for bleeding edge CI

### DIFF
--- a/.github/workflows/bleeding-edge.yaml
+++ b/.github/workflows/bleeding-edge.yaml
@@ -72,7 +72,7 @@ jobs:
         pytest -vvv --color=yes
 
   create-issue:
-    if: ${{ failure() && github.event_name == 'schedule' }}
+    #if: ${{ failure() && github.event_name == 'schedule' }}
     needs: [build]
     permissions:
       issues: write

--- a/.github/workflows/bleeding-edge.yaml
+++ b/.github/workflows/bleeding-edge.yaml
@@ -87,7 +87,7 @@ jobs:
         body: |
           The weekly build with future dependencies has failed. Check the logs
           https://github.com/${{github.repository}}/actions/runs/${{github.run_id}}
-        labels: 'tests: running tests,'
+        #labels: 'tests: running tests,'
         pinned: false
         close-previous: false
       env:

--- a/.github/workflows/bleeding-edge.yaml
+++ b/.github/workflows/bleeding-edge.yaml
@@ -87,7 +87,7 @@ jobs:
         body: |
           The weekly build with future dependencies has failed. Check the logs
           https://github.com/${{github.repository}}/actions/runs/${{github.run_id}}
-        #labels: 'tests: running tests,'
+        labels: 'tests: running tests,'
         pinned: false
         close-previous: false
       env:


### PR DESCRIPTION
Testing this on my fork as it's apparently not possible to do it on the main repo *from a branch emitted via a fork*, because GitHub actions runs as their own user, and don't have access to my permissions (which makes sense)